### PR TITLE
Add original PR target to fetch list

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -354,6 +354,7 @@ export type PullRequest = {
   };
   base: {
     sha: string;
+    ref: string;
   };
   user: {
     login: string;


### PR DESCRIPTION
attempt to add the main PR target branch in the suggestion when backporting a PR that was squashed